### PR TITLE
Make account history JSON parser support indices

### DIFF
--- a/lib/src/hive_api_client.dart
+++ b/lib/src/hive_api_client.dart
@@ -11,6 +11,7 @@ class HiveApiClient {
 
   // TODO(shawnlauzon): Switch to different URLs, https://github.com/LeoFinance/hive-api/issues/1
   static const _baseUrl = 'api.deathwing.me';
+
   // static const _baseUrl = 'api.hive.blog';
 
   static const maxNonce = 1 << 32; // max value of Random.secure()
@@ -197,9 +198,7 @@ class HiveApiClient {
     // See samples/accounts_history.json
     return [
       for (final entry in json)
-        AccountHistoryEntry.fromJson(
-          (entry as List<dynamic>)[1] as Map<String, dynamic>,
-        )
+        AccountHistoryEntry.fromJson(entry as List<dynamic>)
     ];
   }
 

--- a/lib/src/models/account_history_entry.dart
+++ b/lib/src/models/account_history_entry.dart
@@ -3,9 +3,15 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'account_history_entry.g.dart';
 
-@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+@JsonSerializable(
+  fieldRename: FieldRename.snake,
+  explicitToJson: true,
+  createFactory: false,
+  createToJson: false,
+)
 class AccountHistoryEntry {
   const AccountHistoryEntry({
+    required this.historyIndex,
     required this.trxId,
     required this.block,
     required this.trxInBlock,
@@ -15,8 +21,40 @@ class AccountHistoryEntry {
     required this.op,
   });
 
-  factory AccountHistoryEntry.fromJson(Map<String, dynamic> json) =>
-      _$AccountHistoryEntryFromJson(json);
+  // This is the easiest way that doesn't break the current declarative
+  // implementation ongoing for the rest of structs. This is required as account
+  // history is returned as a tuple, and for no apparent reason, json-annotate
+  // library doesn't count root array as valid JSON (which it is), which makes
+  // tuples not being able to used as root in declarative approach. We need
+  // historyIndex to query far away stuff from history.
+  factory AccountHistoryEntry.fromJson(List<dynamic> tupleJson) {
+    final index = tupleJson[0] as int;
+    final data = tupleJson[1] as Map<String, dynamic>;
+
+    return AccountHistoryEntry(
+      historyIndex: index,
+      trxId: data['trx_id'] as String,
+      block: data['block'] as int,
+      trxInBlock: data['trx_in_block'] as int,
+      opInTrx: data['op_in_trx'] as int,
+      virtualOp: data['virtual_op'] as int,
+      timestamp: forceUtcDate(data['timestamp'] as String),
+      op: AccountHistoryEntry._arrayToOp(data['op'] as List),
+    );
+  }
+
+  List<dynamic> toJson() => <dynamic>[
+        historyIndex,
+        <String, dynamic>{
+          'trx_id': trxId,
+          'block': block,
+          'trx_in_block': trxInBlock,
+          'op_in_trx': opInTrx,
+          'virtual_op': virtualOp,
+          'timestamp': stripUtcZ(timestamp),
+          'op': AccountHistoryEntry._opToArray(op),
+        }
+      ];
 
   static Op _arrayToOp(List<dynamic> ar) => Op(
         type: ar[0] as String,
@@ -24,8 +62,10 @@ class AccountHistoryEntry {
             ? VoteOp.fromJson(ar[1] as Map<String, dynamic>)
             : null,
       );
+
   static List<dynamic> _opToArray(Op op) => <dynamic>[op.type, op.data];
 
+  final int historyIndex;
   final String trxId;
   final int block;
   final int trxInBlock;
@@ -37,8 +77,6 @@ class AccountHistoryEntry {
 
   @JsonKey(fromJson: _arrayToOp, toJson: _opToArray)
   final Op op;
-
-  Map<String, dynamic> toJson() => _$AccountHistoryEntryToJson(this);
 
   @override
   String toString() => 'History $op';

--- a/lib/src/models/account_history_entry.g.dart
+++ b/lib/src/models/account_history_entry.g.dart
@@ -6,29 +6,6 @@ part of 'account_history_entry.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-AccountHistoryEntry _$AccountHistoryEntryFromJson(Map<String, dynamic> json) =>
-    AccountHistoryEntry(
-      trxId: json['trx_id'] as String,
-      block: json['block'] as int,
-      trxInBlock: json['trx_in_block'] as int,
-      opInTrx: json['op_in_trx'] as int,
-      virtualOp: json['virtual_op'] as int,
-      timestamp: forceUtcDate(json['timestamp'] as String),
-      op: AccountHistoryEntry._arrayToOp(json['op'] as List),
-    );
-
-Map<String, dynamic> _$AccountHistoryEntryToJson(
-        AccountHistoryEntry instance) =>
-    <String, dynamic>{
-      'trx_id': instance.trxId,
-      'block': instance.block,
-      'trx_in_block': instance.trxInBlock,
-      'op_in_trx': instance.opInTrx,
-      'virtual_op': instance.virtualOp,
-      'timestamp': stripUtcZ(instance.timestamp),
-      'op': AccountHistoryEntry._opToArray(instance.op),
-    };
-
 Op _$OpFromJson(Map<String, dynamic> json) => Op(
       type: json['type'] as String,
       data: json['data'],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hive_api
 description: A simple API for connecting to the Hive network.
-version: 0.2.1
+version: 0.3.0
 repository: https://github.com/LeoFinance/hive-api
 
 environment:


### PR DESCRIPTION
Account history index was being discarded, this fixed it with custom JSON parsing. Dart's json libraries doesn't support JSONs with array being root of them (which is a valid JSON root), because of that I used custom serialize and deserialize tuple struct of history, rather than using declarative annotations, which wasn't possible.

Reason for needing account history index is because it is needed for querying more data than 1000 from account history.